### PR TITLE
Add code version info for SOAP and snapshots

### DIFF
--- a/source/snapshots/snapshot_format.rst
+++ b/source/snapshots/snapshot_format.rst
@@ -30,6 +30,26 @@ useful attributes are:
 | ``NumFilesPerSnapshot`` | Number of files in the snapshot. Always 1 for virtual snapshots.      |
 +-------------------------+-----------------------------------------------------------------------+
 
+Code version
+~~~~~~~~~~~~
+
+The ``Code`` group contains attributes which can be used to determine
+the precise version of SWIFT which was used to run the simulation.
+
++---------------------------+-----------------------------------------------------------------------+
+| Attribute name            | Description                                                           |
++===========================+=======================================================================+
+| ``Code Version``          | SWIFT code version number, as a string                                |
++---------------------------+-----------------------------------------------------------------------+
+| ``Git Branch``            | Name of the git branch which was used                                 |
++---------------------------+-----------------------------------------------------------------------+
+| ``Git Revision``          | Identifies the exact git revision which was used                      |
++---------------------------+-----------------------------------------------------------------------+
+| ``Git Date``              | Date associated with this revision                                    |
++---------------------------+-----------------------------------------------------------------------+
+| ``Configuration options`` | Configure script flags which were used for this run                   |
++---------------------------+-----------------------------------------------------------------------+
+
 Cosmology
 ^^^^^^^^^
 

--- a/source/soap/index.rst
+++ b/source/soap/index.rst
@@ -31,3 +31,8 @@ halo/galaxy definitions, as described within the following pages.
           and the halo centre is defined as the position of the most bound 
           particle of its central subhalo), or satellites.
 
+The SOAP source code is available at `on github
+<https://github.com/SWIFTSIM/SOAP>`__ and the exact git revision which
+was used to generate a halo catalogue can be found by inspecting the
+``git_hash`` attribute of the ``Code`` group in the HDF5 halo
+catalogue file.


### PR DESCRIPTION
This adds a description of the Code group to the snapshot format page. It also adds a note on the top level SOAP page about getting the code version.

We also want to add HBT version info, but we don't have any HBT doc pages yet.